### PR TITLE
fix: Fix export

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,18 @@
-module.exports = {
-  configs: {
-    recommended: {
-      plugins: ['zustand-rules'],
-      rules: {
-        'zustand-rules/enforce-slices-when-large-state': 'warn',
-        'zustand-rules/use-store-selectors': 'error',
-        'zustand-rules/no-state-mutation': 'error',
-        'zustand-rules/enforce-use-setstate': 'error',
-        'zustand-rules/enforce-state-before-actions': 'error'
-      }
+'use strict';
+
+const requireIndex = require('requireindex');
+
+module.exports.rules = requireIndex(`${__dirname}/rules`);
+
+module.exports.configs = {
+  recommended: {
+    plugins: ['zustand-rules'],
+    rules: {
+      'zustand-rules/enforce-slices-when-large-state': 'warn',
+      'zustand-rules/use-store-selectors': 'error',
+      'zustand-rules/no-state-mutation': 'error',
+      'zustand-rules/enforce-use-setstate': 'error',
+      'zustand-rules/enforce-state-before-actions': 'error'
     }
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^5.2.1",
         "jest": "^29.7.0",
+        "requireindex": "^1.2.0",
         "semantic-release": "^24.1.2"
       },
       "peerDependencies": {
@@ -11401,6 +11402,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.5"
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^5.2.1",
     "jest": "^29.7.0",
+    "requireindex": "^1.2.0",
     "semantic-release": "^24.1.2"
   },
   "repository": {


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
