### PR TITLE
fix: Add check for Identifier type

### DIFF
--- a/lib/rules/use-store-selectors.js
+++ b/lib/rules/use-store-selectors.js
@@ -11,6 +11,8 @@ module.exports = {
   create(context) {
     return {
       CallExpression(node) {
+        if (node.callee.type !== 'Identifier') { return }
+
         if (node.callee.name.startsWith('use') && node.callee.name.endsWith('Store')) {
           const args = node.arguments;
 


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
