### PR TITLE
fix: reexport rules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,14 @@
 'use strict';
 
-const requireIndex = require('requireindex');
+module.exports.rules = {
+  'enforce-slices-when-large-state': require('./rules/enforce-slices-when-large-state'),
+  'enforce-state-before-actions': require('./rules/enforce-state-before-actions'),
+  'enforce-use-setstate': require('./rules/enforce-use-setstate'),
+  'enforce-no-multiple-stores': require('./rules/enforce-no-multiple-stores'),
+  'enforce-no-state-mutation': require('./rules/enforce-no-state-mutation'),
+  'use-store-selectors': require('./rules/use-store-selectors'),
 
-module.exports.rules = requireIndex(`${__dirname}/rules`);
+}
 
 module.exports.configs = {
   recommended: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,10 +4,9 @@ module.exports.rules = {
   'enforce-slices-when-large-state': require('./rules/enforce-slices-when-large-state'),
   'enforce-state-before-actions': require('./rules/enforce-state-before-actions'),
   'enforce-use-setstate': require('./rules/enforce-use-setstate'),
-  'enforce-no-multiple-stores': require('./rules/enforce-no-multiple-stores'),
-  'enforce-no-state-mutation': require('./rules/enforce-no-state-mutation'),
+  'no-multiple-stores': require('./rules/no-multiple-stores'),
+  'no-state-mutation': require('./rules/no-state-mutation'),
   'use-store-selectors': require('./rules/use-store-selectors'),
-
 }
 
 module.exports.configs = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^5.2.1",
         "jest": "^29.7.0",
-        "requireindex": "^1.2.0",
         "semantic-release": "^24.1.2"
       },
       "peerDependencies": {
@@ -11402,16 +11401,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/requireindex": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
-      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.5"
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^5.2.1",
     "jest": "^29.7.0",
-    "requireindex": "^1.2.0",
     "semantic-release": "^24.1.2"
   },
   "repository": {


### PR DESCRIPTION


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
